### PR TITLE
fix: 升级 CI Node 版本至 20.19.0 以兼容 lerna@9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.19.0'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 


### PR DESCRIPTION
lerna@9 要求 node ^20.19.0，'20' 可能安装低于该版本的
Node 导致 CI 失败，锁定为 20.19.0。