### PR TITLE
fix: 升级 doc CI Node 版本至 20.19.0 以兼容 lerna@9

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20.19.0'
 
       # 环境信息
       - name: Display environment info
@@ -40,7 +40,7 @@ jobs:
       - name: Build and deploy
         run: |
           cd gmfe
-          yarn install
+          yarn install --ignore-engines
           npm run build
           rm -rf .github && rm -rf .storybook && rm -rf packages
           git add --all


### PR DESCRIPTION
yarn install 添加 --ignore-engines 参数，修复 CI 因 lerna engines 检查失败的问题。