### PR TITLE
docs: 补充 react/react-deprecated/frame/tour 包缺失的示例章节，更新 tour API 与源码一致

### DIFF
--- a/packages/frame/README.md
+++ b/packages/frame/README.md
@@ -120,6 +120,165 @@ function App() {
 | className | 自定义类名 | `string` | - | 否 |
 | style | 自定义样式 | `object` | - | 否 |
 
+## 示例
+
+### 完整后台布局
+
+```jsx
+import React from 'react'
+import { Framework, RightTop, Breadcrumb, Info, CopyRight, FullTabV2 } from '@gmfe/frame'
+import { Nav } from '@gmfe/react'
+
+const menuData = [
+  {
+    name: '商品管理',
+    link: '/merchandise',
+    sub: [
+      { name: '商品列表', link: '/merchandise/list' },
+      { name: '分类管理', link: '/merchandise/category' }
+    ]
+  },
+  { name: '订单管理', link: '/order' }
+]
+
+const navConfig = [
+  {
+    link: '/merchandise',
+    name: '商品管理',
+    sub: [
+      { name: '商品列表', link: '/merchandise/list', sub: [] },
+      { name: '分类管理', link: '/merchandise/category', sub: [] }
+    ]
+  },
+  { link: '/order', name: '订单管理', sub: [] }
+]
+
+function App() {
+  return (
+    <Framework
+      menu={<Nav data={menuData} />}
+      leftWidth="220px"
+    >
+      <RightTop
+        breadcrumb={
+          <Breadcrumb
+            breadcrumbs={[]}
+            pathname={location.pathname}
+            navConfig={navConfig}
+            onSelect={(item) => console.log(item)}
+          />
+        }
+        info={
+          <Info
+            more={[
+              { text: '个人设置', onClick: () => {} },
+              { text: '退出登录', onClick: () => {} }
+            ]}
+          >
+            <span>管理员</span>
+          </Info>
+        }
+      />
+      <FullTabV2
+        tabs={[
+          { name: '全部', key: 'all', content: <div>全部订单</div> },
+          { name: '待付款', key: 'pending', content: <div>待付款订单</div> },
+          { name: '已完成', key: 'done', content: <div>已完成订单</div> }
+        ]}
+        defaultActiveKey="all"
+        onChange={(key) => console.log('切换到', key)}
+      />
+      <CopyRight />
+    </Framework>
+  )
+}
+```
+
+### 全屏模式（无左侧菜单）
+
+```jsx
+import { Framework, FullTabV2 } from '@gmfe/frame'
+
+function FullScreenPage() {
+  return (
+    <Framework isFullScreen>
+      <FullTabV2
+        tabs={[
+          { name: '概览', key: 'overview', content: <div>数据概览</div> },
+          { name: '详情', key: 'detail', content: <div>详细数据</div> }
+        ]}
+        defaultActiveKey="overview"
+      />
+    </Framework>
+  )
+}
+```
+
+### 移动端适配
+
+```jsx
+import React, { useState } from 'react'
+import { Framework, Left, RightTop, Breadcrumb, Info, FullTabV2 } from '@gmfe/frame'
+import { Nav, Mask } from '@gmfe/react'
+
+function MobileApp() {
+  const [showMenu, setShowMenu] = useState(false)
+
+  return (
+    <>
+      <Framework
+        showMobileMenu
+        leftWidth="220px"
+      >
+        <RightTop
+          onMenuBtnClick={() => setShowMenu(true)}
+          breadcrumb={<Breadcrumb breadcrumbs={[]} pathname={location.pathname} navConfig={[]} onSelect={() => {}} />}
+          info={<Info><span>管理员</span></Info>}
+        />
+        <div>页面内容</div>
+      </Framework>
+
+      {showMenu && (
+        <Mask onMaskClick={() => setShowMenu(false)}>
+          <div style={{ width: '220px', height: '100vh', background: '#fff' }}>
+            <Nav data={menuData} />
+          </div>
+        </Mask>
+      )}
+    </>
+  )
+}
+```
+
+### FullTab 受控模式
+
+```jsx
+import { useState } from 'react'
+import { FullTabV2 } from '@gmfe/frame'
+
+function ControlledTabs() {
+  const [activeKey, setActiveKey] = useState('tab1')
+
+  const handleSwitchToDetail = () => {
+    setActiveKey('tab2')
+  }
+
+  return (
+    <div>
+      <button onClick={handleSwitchToDetail}>跳转到详情标签</button>
+      <FullTabV2
+        tabs={[
+          { name: '列表', key: 'tab1', content: <div>列表内容</div> },
+          { name: '详情', key: 'tab2', content: <div>详情内容</div> }
+        ]}
+        activeKey={activeKey}
+        onChange={setActiveKey}
+      />
+    </div>
+  )
+}
+```
+
 ## 注意事项
 
 - `Breadcrumb` 在移动端会自动隐藏。

--- a/packages/react-deprecated/README.md
+++ b/packages/react-deprecated/README.md
@@ -126,6 +126,142 @@ import { SearchSelect, TreeSelect, QuickPanel, QuickTab, QuickFilter, Pagination
 | process | 流程步骤数组，每项包含 `name` 和 `value` | `array` | - | 是 |
 | unit | 单位文字 | `string` | - | 是 |
 
+## 示例
+
+### SearchSelect 搜索选择
+
+```jsx
+import { SearchSelect } from '@gmfe/react-deprecated'
+
+function App() {
+  const [selected, setSelected] = useState(null)
+
+  return (
+    <SearchSelect
+      list={searchResults}
+      onSearch={async (query) => {
+        const res = await api.search(query)
+        return res.list
+      }}
+      onSelect={(item) => setSelected(item)}
+      selected={selected}
+      placeholder="请搜索商品"
+    />
+  )
+}
+```
+
+### SearchSelect 多选模式
+
+```jsx
+import { SearchSelect } from '@gmfe/react-deprecated'
+
+function App() {
+  const [selected, setSelected] = useState([])
+
+  return (
+    <SearchSelect
+      list={searchResults}
+      onSearch={async (query) => await api.search(query)}
+      onSelect={(item) => setSelected(item)}
+      selected={selected}
+      multiple
+      renderListCell={(item) => `${item.name}（${item.code}）`}
+    />
+  )
+}
+```
+
+### TreeSelect 树形选择
+
+```jsx
+import { TreeSelect } from '@gmfe/react-deprecated'
+
+function App() {
+  const treeData = [
+    {
+      name: '华东区域',
+      id: 1,
+      sub: [
+        { name: '上海', id: 11, sub: [{ name: '浦东新区', id: 111 }] },
+        { name: '浙江', id: 12 }
+      ]
+    }
+  ]
+
+  const [selected, setSelected] = useState([])
+
+  return (
+    <TreeSelect
+      list={treeData}
+      selected={selected}
+      onSelect={(ids) => setSelected(ids)}
+    />
+  )
+}
+```
+
+### QuickPanel + QuickTab 组合使用
+
+```jsx
+import { QuickPanel, QuickTab } from '@gmfe/react-deprecated'
+
+function App() {
+  const [activeTab, setActiveTab] = useState(0)
+
+  return (
+    <QuickPanel title="数据概览">
+      <QuickTab
+        tabs={['按订单查看', '按商品查看', '按司机查看']}
+        active={activeTab}
+        onChange={setActiveTab}
+      />
+      {activeTab === 0 && <div>订单数据</div>}
+      {activeTab === 1 && <div>商品数据</div>}
+      {activeTab === 2 && <div>司机数据</div>}
+    </QuickPanel>
+  )
+}
+```
+
+### 废弃组件迁移指南
+
+以下示例展示如何将废弃组件迁移到推荐替代方案：
+
+```jsx
+// ❌ 废弃用法 - SearchSelect
+import { SearchSelect } from '@gmfe/react-deprecated'
+<SearchSelect list={list} onSearch={fn} onSelect={fn} />
+
+// ✅ 推荐替代 - MoreSelect
+import { MoreSelect } from '@gmfe/react'
+<MoreSelect list={list} onChange={fn} />
+
+// ❌ 废弃用法 - TreeSelect
+import { TreeSelect } from '@gmfe/react-deprecated'
+<TreeSelect list={treeData} onSelect={fn} />
+
+// ✅ 推荐替代 - TreeV2
+import { TreeV2 } from '@gmfe/react'
+<TreeV2 data={treeData} onSelect={fn} />
+
+// ❌ 废弃用法 - QuickPanel
+import { QuickPanel } from '@gmfe/react-deprecated'
+<QuickPanel title="标题">内容</QuickPanel>
+
+// ✅ 推荐替代 - Collapse
+import { Collapse } from '@gmfe/react'
+<Collapse in title="标题">内容</Collapse>
+
+// ❌ 废弃用法 - QuickTab
+import { QuickTab } from '@gmfe/react-deprecated'
+<QuickTab tabs={['A', 'B']} active={0} onChange={fn} />
+
+// ✅ 推荐替代 - Tabs
+import { Tabs } from '@gmfe/react'
+<Tabs tabs={['A', 'B']} active={0} onChange={fn} />
+```
+
 ## 注意事项
 
 - 此包中的组件已废弃，新项目建议使用 `@gmfe/react` 中的对应组件替代。

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -24,7 +24,123 @@ function App() {
 }
 ```
 
-## 组件列表
+## 示例
+
+### 表单提交
+
+```jsx
+import { Form, FormItem, FormButton, Button } from '@gmfe/react'
+
+function App() {
+  return (
+    <Form
+      labelWidth="100px"
+      onSubmit={(values) => console.log('提交数据', values)}
+    >
+      <FormItem label="名称" required>
+        <input name="name" placeholder="请输入名称" />
+      </FormItem>
+      <FormItem label="数量">
+        <input name="quantity" type="number" />
+      </FormItem>
+      <FormButton>
+        <Button type="primary" htmlType="submit">提交</Button>
+        <Button htmlType="reset">重置</Button>
+      </FormButton>
+    </Form>
+  )
+}
+```
+
+### 多栏表单布局
+
+```jsx
+import { Form, FormItem, FormButton, FormBlock, Button, Select } from '@gmfe/react'
+
+function App() {
+  return (
+    <Form labelWidth="100px">
+      <FormBlock col={2}>
+        <FormItem label="名称" required>
+          <input name="name" />
+        </FormItem>
+        <FormItem label="地区">
+          <Select data={areaList} />
+        </FormItem>
+      </FormBlock>
+      <FormButton>
+        <Button type="primary" htmlType="submit">提交</Button>
+      </FormButton>
+    </Form>
+  )
+}
+```
+
+### 弹窗交互
+
+```jsx
+import { Button, Dialog, Drawer } from '@gmfe/react'
+
+function App() {
+  return (
+    <div>
+      <Button onClick={() => Dialog.alert('操作成功')}>提示</Button>
+
+      <Button onClick={() => {
+        Dialog.confirm({
+          title: '确认删除',
+          children: '删除后不可恢复，是否继续？',
+          onOK: async () => {
+            await deleteApi()
+          }
+        })
+      }}>确认对话框</Button>
+
+      <Button onClick={() => {
+        Drawer.open({
+          title: '详情',
+          children: <div>抽屉内容</div>
+        })
+      }}>打开抽屉</Button>
+    </div>
+  )
+}
+```
+
+### Sheet 底部弹出表格
+
+```jsx
+import { Sheet, SheetColumn, SheetSelect, SheetAction, Button } from '@gmfe/react'
+
+function App() {
+  const [data, setData] = useState(listData)
+  const [selected, setSelected] = useState([])
+
+  return (
+    <Sheet list={data}>
+      <SheetColumn field="id" name="ID" />
+      <SheetColumn field="name" name="名称" />
+      <SheetColumn field="name" name="描述">
+        {(name, index, record) => `商品：${name}，编号：${record.id}`}
+      </SheetColumn>
+      <SheetSelect
+        onSelect={(checked, index) => {
+          const next = data.slice()
+          next[index]._gm_select = checked
+          setData(next)
+        }}
+      />
+      <SheetAction>
+        {(checkedList) => (
+          <Button onClick={() => console.log('已选', checkedList)}>批量操作</Button>
+        )}
+      </SheetAction>
+    </Sheet>
+  )
+}
+```
+
+### 组件列表
 
 ### 表单组件
 

--- a/packages/tour/README.md
+++ b/packages/tour/README.md
@@ -21,11 +21,11 @@ function App() {
 
   const steps = [
     {
-      target: '#step1',
+      selector: '#step1',
       content: '这是第一步引导，点击这里开始操作'
     },
     {
-      target: '#step2',
+      selector: '#step2',
       content: '这是第二步引导，这里是核心功能区域'
     }
   ]
@@ -38,11 +38,8 @@ function App() {
       <Tour
         isOpen={isOpen}
         steps={steps}
-        currentStep={0}
-        onPrev={() => {}}
-        onNext={() => {}}
+        startAt={0}
         onRequestClose={() => setIsOpen(false)}
-        disableInteraction={false}
       />
     </div>
   )
@@ -53,21 +50,242 @@ function App() {
 
 ### Tour
 
-引导组件，默认导出。
+引导组件，默认导出。支持通过 `ref` 调用实例方法。
+
+#### Props
 
 | 属性 | 说明 | 类型 | 默认值 | 必填 |
 |------|------|------|--------|------|
-| isOpen | 是否显示引导 | `boolean` | `false` | 否 |
-| steps | 引导步骤数组 | `array` | - | 否 |
-| currentStep | 当前步骤索引 | `number` | `0` | 否 |
-| onPrev | 上一步回调 | `function` | - | 否 |
-| onNext | 下一步回调 | `function` | - | 否 |
-| onRequestClose | 关闭引导回调 | `function` | - | 否 |
-| disableInteraction | 是否禁用与高亮元素的交互 | `boolean` | `false` | 否 |
+| isOpen | 是否显示引导 | `boolean` | - | 是 |
+| children | 自定义内容，渲染在引导气泡内 | `ReactNode` | - | 否 |
+| className | 引导气泡的自定义类名 | `string` | - | 否 |
+| steps | 引导步骤配置数组，详见下方 Step 配置 | `array<Step>` | - | 否 |
+| startAt | 开始时展示的步骤索引 | `number` | `0` | 否 |
+| scrollDuration | 自动滚动到目标元素的动画时长（秒） | `number` | `1` | 否 |
+| maskSpace | 高亮区域与引导内容的间隙（像素） | `number` | `10` | 否 |
+| maskClassName | SVG 遮罩层的自定义类名 | `string` | - | 否 |
+| closeWithMask | 是否允许点击遮罩关闭引导 | `boolean` | `false` | 否 |
+| disableButtons | 是否隐藏内置的上一步/下一步按钮 | `boolean` | `false` | 否 |
+| disableInteraction | 是否禁止与高亮元素的交互 | `boolean` | `true` | 否 |
+| disableInteractionClassName | 禁用交互时覆盖层的自定义类名 | `string` | - | 否 |
+| rounded | 高亮区域的圆角大小（像素） | `number` | `3` | 否 |
+| onAfterOpen | 引导打开后的回调，参数为 helper DOM 节点 | `function(helper)` | - | 否 |
+| onBeforeClose | 引导关闭前的回调，参数为 helper DOM 节点 | `function(helper)` | - | 否 |
+| onRequestClose | 关闭引导的回调 | `function` | - | 否 |
+
+#### Step 配置
+
+`steps` 数组中每项的字段说明：
+
+| 属性 | 说明 | 类型 | 必填 |
+|------|------|------|------|
+| selector | 目标元素的 CSS 选择器 | `string` | 是 |
+| content | 引导内容，支持文本或 React 元素 | `ReactNode` | 是 |
+| position | 引导气泡的位置 | `'top' \| 'right' \| 'bottom' \| 'left' \| 'center' \| number[]` | 否 |
+| observe | 监听 DOM 变化的观察节点选择器 | `string` | 否 |
+| actionBefore | 步骤展示前的钩子，支持异步函数 | `function` | 否 |
+| actionAfter | 步骤展示后（离开前）的钩子，参数为目标 DOM 节点，支持异步 | `function(node)` | 否 |
+| style | 引导气泡的自定义样式 | `object` | 否 |
+| stepInteraction | 当前步骤是否允许用户与高亮元素交互 | `boolean` | 否 |
+
+#### 实例方法（通过 ref 调用）
+
+| 方法 | 说明 | 参数 |
+|------|------|------|
+| `apiToNextStep()` | 切换到下一步 | - |
+| `apiClose()` | 关闭引导 | - |
+| `apiRecalculate()` | 重新计算引导位置（窗口变化后手动触发） | - |
+
+## 示例
+
+### 基础分步引导
+
+```jsx
+import Tour from '@gmfe/tour'
+import { useState } from 'react'
+
+function App() {
+  const [isOpen, setIsOpen] = useState(true)
+
+  return (
+    <div>
+      <div id="step-create" data-id="btn-create">
+        <button>新建订单</button>
+      </div>
+      <div data-id="table-area">
+        <table>...</table>
+      </div>
+
+      <Tour
+        isOpen={isOpen}
+        steps={[
+          {
+            selector: '[data-id="btn-create"]',
+            content: '点击这里创建新订单'
+          },
+          {
+            selector: '[data-id="table-area"]',
+            content: '这里是订单列表，可以查看和管理所有订单'
+          }
+        ]}
+        onRequestClose={() => setIsOpen(false)}
+      />
+    </div>
+  )
+}
+```
+
+### 带位置控制的多步引导
+
+```jsx
+import Tour from '@gmfe/tour'
+import { useState } from 'react'
+
+function App() {
+  const [isOpen, setIsOpen] = useState(true)
+
+  return (
+    <div>
+      <button className="btn-start">开始</button>
+      <input className="input-search" placeholder="搜索..." />
+      <button className="btn-submit">提交</button>
+
+      <Tour
+        isOpen={isOpen}
+        startAt={0}
+        maskSpace={10}
+        rounded={3}
+        steps={[
+          {
+            selector: '.btn-start',
+            content: '点击开始按钮启动流程',
+            position: 'bottom'
+          },
+          {
+            selector: '.input-search',
+            content: '输入关键词进行搜索',
+            position: 'bottom',
+            stepInteraction: true
+          },
+          {
+            selector: '.btn-submit',
+            content: '确认无误后点击提交',
+            position: 'top'
+          }
+        ]}
+        onRequestClose={() => setIsOpen(false)}
+      />
+    </div>
+  )
+}
+```
+
+### 自定义操作按钮
+
+```jsx
+import Tour from '@gmfe/tour'
+import { useState, useRef } from 'react'
+import { Flex, Button } from '@gmfe/react'
+
+function App() {
+  const [isOpen, setIsOpen] = useState(true)
+  const tourRef = useRef(null)
+
+  const handleNext = () => {
+    tourRef.current.apiToNextStep()
+  }
+
+  const handleClose = () => {
+    tourRef.current.apiClose()
+  }
+
+  return (
+    <div>
+      <div className="target-1">目标元素 1</div>
+      <div className="target-2">目标元素 2</div>
+
+      <Tour
+        ref={tourRef}
+        disableButtons
+        isOpen={isOpen}
+        steps={[
+          {
+            selector: '.target-1',
+            content: (
+              <div>
+                <div>第一步：点击"下一步"继续</div>
+                <Flex justifyEnd className="gm-padding-top-10">
+                  <Button type="primary" onClick={handleNext}>下一步</Button>
+                </Flex>
+              </div>
+            )
+          },
+          {
+            selector: '.target-2',
+            content: (
+              <div>
+                <div>第二步：点击"知道了"完成引导</div>
+                <Flex justifyEnd className="gm-padding-top-10">
+                  <Button type="primary" onClick={handleClose}>知道了</Button>
+                </Flex>
+              </div>
+            )
+          }
+        ]}
+        onRequestClose={() => setIsOpen(false)}
+      />
+    </div>
+  )
+}
+```
+
+### 配合按钮触发引导
+
+```jsx
+import Tour from '@gmfe/tour'
+import { useState } from 'react'
+import { Button } from '@gmfe/react'
+
+function App() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div>
+      <Button onClick={() => setIsOpen(true)}>查看操作指引</Button>
+
+      <div className="guide-step-1">功能区域一</div>
+      <div className="guide-step-2">功能区域二</div>
+
+      <Tour
+        isOpen={isOpen}
+        closeWithMask={false}
+        disableInteraction={true}
+        steps={[
+          {
+            selector: '.guide-step-1',
+            content: '这是功能区域一，展示核心数据'
+          },
+          {
+            selector: '.guide-step-2',
+            content: '这是功能区域二，支持筛选和导出',
+            stepInteraction: true
+          }
+        ]}
+        onAfterOpen={() => console.log('引导已打开')}
+        onBeforeClose={() => console.log('引导即将关闭')}
+        onRequestClose={() => setIsOpen(false)}
+      />
+    </div>
+  )
+}
+```
 
 ## 注意事项
 
-- 引导组件仅在 `isOpen` 为 `true` 时渲染。
-- 使用 SVG 遮罩实现高亮效果，点击遮罩区域可关闭引导。
+- 引导组件仅在 `isOpen` 为 `true` 时渲染，组件内部使用 Portal 渲染到 body 下。
+- 使用 SVG 遮罩实现高亮效果，默认不可通过点击遮罩关闭（需设置 `closeWithMask: true`）。
+- `disableInteraction` 默认为 `true`，即禁止用户与高亮元素交互；可通过单个步骤的 `stepInteraction: true` 覆盖。
 - 组件需要 `react` >= 16.13.0 和 `styled-components` ^5.1.0 作为 peer dependency。
-- 步骤内容通过 children 或步骤配置传入。
+- 目标元素不在视口中时会自动滚动到该元素，滚动时长由 `scrollDuration` 控制。
+- 组件内部使用 MutationObserver 监听 DOM 变化，自动更新引导位置。
+- `actionAfter` 钩子在离开当前步骤前执行，参数为目标 DOM 节点，支持异步函数（如 `await node.click()`）。


### PR DESCRIPTION
- @gmfe/react: 新增表单提交、多栏布局、弹窗交互、Sheet 表格示例
- @gmfe/react-deprecated: 新增组件用法示例及废弃组件迁移指南
- @gmfe/frame: 新增完整布局、全屏模式、移动端适配、受控标签页示例
- @gmfe/tour: 新增基础引导、位置控制、自定义按钮、按钮触发示例；修正 API 章节（selector/target、startAt/currentStep、ref 方法等）